### PR TITLE
Support bib having volume without number 

### DIFF
--- a/robomech.bst
+++ b/robomech.bst
@@ -520,7 +520,11 @@ FUNCTION {format.vol.num.pages}
         % !!!!MODIFIED!!!!
         % Uncapitalize and connect to number with dash
         % {"Vol." volume tie.or.space.connect ", " * }
-        {"vol." volume tie.or.space.connect "-" * }
+        { number empty$
+          {"vol." volume tie.or.space.connect ", " * }
+          {"vol." volume tie.or.space.connect "-" * }
+          if$
+        }
        if$
      }
 

--- a/robomech.bst
+++ b/robomech.bst
@@ -516,10 +516,7 @@ FUNCTION {format.vol.num.pages}
 
 
      { volume is.kanji.str$
-        % !!!!MODIFIED!!!!
-        % Connect to number with dash
-        % {volume  ", " * }
-        {volume  "-" * }
+        {volume  ", " * }
         % !!!!MODIFIED!!!!
         % Uncapitalize and connect to number with dash
         % {"Vol." volume tie.or.space.connect ", " * }


### PR DESCRIPTION
Without this PR, unnecessary dash remains after volume when number doesn't exist.
"vol. 64-pp. 3854" -> "vol. 64, pp. 3854"

(Minor fix) 「第64巻-第591号」→「第64巻, 第591号」